### PR TITLE
Bugfix/sticky suspects auto alpha

### DIFF
--- a/db/db_utils.py
+++ b/db/db_utils.py
@@ -36,7 +36,8 @@ class DbConnection:
                 "trouser_colour": suspect_info[6],
                 "shoe_colour": suspect_info[7],
                 "wears_a_hat": "wears a hat" if bool(suspect_info[8]) == True else "doesn't wear a hat",
-                "alpha" : 255 # transparency value - default to full visibility
+                "alpha": 255,  # transparency value - default to full visibility
+                "suspect_rect_img": None
             })
         return suspect_details
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from db.db_utils import DbConnection
 from src.clues import Clues
-from src.game_config.event_handler import EventHandler
+from src.game_config.getters_setters import GettersSetters
 from src.game_config.utils import *
 from src.game_state_manager import GameStateManager
 from src.game_config.global_config import *
@@ -34,11 +34,11 @@ class Game:
 
         self.main_menu = MainMenu(self.screen, self.game_state_manager, self.draw)
         self.rules = Rules(self.screen, self.game_state_manager, self.draw, self.timer)
-        self.event_handler = EventHandler()
+        self.event_handler = GettersSetters()
         self.question = Question(self.screen, self.game_state_manager, self.draw, self.timer, self.event_handler)
         self.suspects = Suspects(self.screen, self.game_state_manager, self.draw, self.murderer)
         self.wrong_answer = WrongAnswer(self.screen, self.game_state_manager, self.draw, self.timer, self.question,
-                                        self.button_handler)
+                                        self.button_handler, self.event_handler)
         self.correct_answer = CorrectAnswer(self.screen, self.game_state_manager, self.draw, self.timer, self.question,
                                             self.clues, self.button_handler, self.suspects, self.event_handler)
         self.arrest_suspect = ArrestSuspect(self.screen, self.game_state_manager, self.draw, self.timer, self.suspects)

--- a/src/game_config/event_handler.py
+++ b/src/game_config/event_handler.py
@@ -1,9 +1,0 @@
-class EventHandler:
-    def __init__(self):
-        self.active_clue = ""
-
-    def set_clue(self, clue):
-        self.active_clue = clue
-
-    def get_clue(self):
-        return self.active_clue

--- a/src/game_config/getters_setters.py
+++ b/src/game_config/getters_setters.py
@@ -1,0 +1,16 @@
+class GettersSetters:
+    def __init__(self):
+        self.active_clue = ""
+        self.wrong_answer_text = ""
+
+    def set_clue(self, clue):
+        self.active_clue = clue
+
+    def get_clue(self):
+        return self.active_clue
+
+    def set_wrong_answer_text(self, text):
+        self.wrong_answer_text = text
+
+    def get_wrong_answer_text(self):
+        return self.wrong_answer_text

--- a/src/screens/arrest_suspect.py
+++ b/src/screens/arrest_suspect.py
@@ -22,6 +22,7 @@ class ArrestSuspect(BaseScreen):
 
     def run(self):
         self.draw_screen()
+        self.suspects.check_button_pressed()
 
 
 if __name__ == "__main__":

--- a/src/screens/correct_answer.py
+++ b/src/screens/correct_answer.py
@@ -11,7 +11,6 @@ class CorrectAnswer(BaseScreen):
         self.clues = clues
         self.button_handler = button_handler
         self.suspects = suspects
-        self.draw_suspects = self.suspects.draw_suspects()
         self.event_handler = event_handler
 
     def draw_correct_answer(self):
@@ -27,7 +26,6 @@ class CorrectAnswer(BaseScreen):
         if not current_clue:
             new_clue = f"Clue: {self.clues.get_clue()}"
             self.event_handler.set_clue(new_clue)
-            print(f"Clue: {current_clue}")
 
         # Render the clue text
         self.draw.render_text(str(current_clue), MEDIUM_FONT, (SCREEN_WIDTH // 2, 115))
@@ -47,12 +45,14 @@ class CorrectAnswer(BaseScreen):
         self.draw_correct_answer()
         self.draw_clue()
         self.draw_info_text()
-        self.suspects.draw_suspects()
-        self.button_handler.arrest()
 
     def run(self):
         self.draw_screen()
         self.check_question_status()
+        self.button_handler.arrest()
+        self.suspects.draw_suspects() # must be immediately before check_pressed due to rendering
+        self.suspects.check_button_pressed()
+
 
 
 if __name__ == "__main__":

--- a/src/screens/questions.py
+++ b/src/screens/questions.py
@@ -108,6 +108,7 @@ class Question(BaseScreen):
                     print(
                         f"Q{self.index + 1}: The player chose the INCORRECT answer. Correct answer was {self.correct_answers[self.index]}")
                     self.game_state_manager.set_state("wrong_answer")
+                    self.event_handler.set_wrong_answer_text("")
                 self.index += 1
                 self.create_buttons()
 

--- a/src/screens/questions.py
+++ b/src/screens/questions.py
@@ -95,7 +95,7 @@ class Question(BaseScreen):
 
     # for each button, a different state is set depending on correct/incorrect answer
     def checks_answer_pressed(self):
-        # print(self.correct_answers[self.index]) # used for debugging/testing
+        # print(self.correct_answers[self.index])  # used for debugging/testing
         for button in self.buttons:
             if button.is_pressed():
                 if button.text == self.correct_answers[self.index]:
@@ -103,15 +103,13 @@ class Question(BaseScreen):
                         f"Q{self.index + 1}: The player chose the CORRECT answer! Correct answer was {self.correct_answers[self.index]}")
                     self.game_state_manager.set_state("correct_answer")
                     self.event_handler.set_clue("")
-                    self.index += 1
-                    self.create_buttons()
 
                 elif button.text in self.incorrect_answers[self.index]:
                     print(
                         f"Q{self.index + 1}: The player chose the INCORRECT answer. Correct answer was {self.correct_answers[self.index]}")
                     self.game_state_manager.set_state("wrong_answer")
-                    self.index += 1
-                    self.create_buttons()
+                self.index += 1
+                self.create_buttons()
 
 
     def run(self):

--- a/src/screens/suspects.py
+++ b/src/screens/suspects.py
@@ -34,36 +34,42 @@ class Suspects:
                 x, y = x_starting_pos, 550
 
             suspect_img_rect = self.draw_suspect(suspect, x, y, n)
-            self.check_button_press(suspect, suspect_img_rect, n)
-
             x += 200
             n += 1
 
-    def check_button_press(self, suspect, suspect_img_rect, n):
+            suspect["suspect_img_rect"] = suspect_img_rect
+        pygame.display.update()
+
+    # Checks if user clicks on image
+    def check_button_pressed(self):
         position = pygame.mouse.get_pos()
-        pressed = pygame.mouse.get_pressed()
 
-        if self.game_state_manager.get_state() == "correct_answer":
+        for event in pygame.event.get():
+            if event.type == pygame.MOUSEBUTTONDOWN:
+                for suspect in self.suspects:
+                    if suspect["suspect_img_rect"].collidepoint(position):
+                        if self.game_state_manager.get_state() == "correct_answer":
+                            self.suspect_press(suspect)
+                        elif self.game_state_manager.get_state() == "arrest_suspect":
+                            self.murderer_guess(suspect, position)
 
-            if suspect_img_rect.collidepoint(position) and pressed[0]:
-                if suspect["alpha"] == 255:
-                    suspect["alpha"] = 100
+    # Changes transparency when suspect clicked
+    @staticmethod
+    def suspect_press(suspect):
+        if suspect["alpha"] == 255:
+            suspect["alpha"] = 100  # Fade the suspect
+        else:
+            suspect["alpha"] = 255  # Bring the suspect back to full opacity
 
-                else:
-                    suspect["alpha"] = 255
-
-
-        # Checks when the mouse is pressed
-        elif self.game_state_manager.get_state() == "arrest_suspect":
-
-            if suspect_img_rect.collidepoint(position) and pressed[0]:
-                if self.murderer[0]["suspect_id"] == self.suspects[n]["suspect_id"]:
-                    print("The murder has been caught!")
-                    self.game_state_manager.set_state("game_won")
-
-                else:
-                    print("Incorrect arrest")
-                    self.game_state_manager.set_state("game_lost")
+    # Checks if player has arrested the murderer
+    def murderer_guess(self, suspect, position):
+        if suspect["suspect_img_rect"].collidepoint(position):
+            if self.murderer[0]["suspect_id"] == suspect["suspect_id"]:
+                print("The murder has been caught!")
+                self.game_state_manager.set_state("game_won")
+            else:
+                print("Incorrect arrest")
+                self.game_state_manager.set_state("game_lost")
 
 
 if __name__ == "__main__":

--- a/src/screens/wrong_answer.py
+++ b/src/screens/wrong_answer.py
@@ -11,8 +11,8 @@ class WrongAnswer(BaseScreen):
         self.button_handler = button_handler
         self.text = [
             "Wrong answer. The killer heard you...",
-            "Wrong. The killer is one step closer to finding you!",
-            "You're running out of places to hide..."
+            "Wrong answer. The killer is one step closer to finding you!",
+            "Wrong answer! You're running out of places to hide..."
         ]
 
         self.message = random.choice(self.text)

--- a/src/screens/wrong_answer.py
+++ b/src/screens/wrong_answer.py
@@ -4,37 +4,41 @@ import random
 
 
 class WrongAnswer(BaseScreen):
-    def __init__(self, screen, game_state_manager, draw, timer, question, button_handler):
+    def __init__(self, screen, game_state_manager, draw, timer, question, button_handler, event_handler):
         super().__init__(screen, game_state_manager, draw)
         self.timer = timer
         self.question = question
         self.button_handler = button_handler
-        self.text = [
-            "Wrong answer. The killer heard you...",
+        self.event_handler = event_handler
+        self.wrong_answer = [
+            "Wrong answer! The killer heard you...",
             "Wrong answer. The killer is one step closer to finding you!",
             "Wrong answer! You're running out of places to hide..."
         ]
 
-        self.message = random.choice(self.text)
+    # draws random wrong answer text
+    def draw_screen(self):
+        # Retrieves current wrong answer text
+        wrong_answer_text = self.event_handler.get_wrong_answer_text()
 
+        # If there is no wrong answer set, set a new random wrong answer text
+        if not wrong_answer_text:
+            wrong_answer_text = random.choice(self.wrong_answer)
+            self.event_handler.set_wrong_answer_text(wrong_answer_text)
 
-    def draw_screen(self, text):
-        self.draw.render_text(text, MEDIUM_FONT, (SCREEN_WIDTH // 2, SCREEN_HEIGHT // 2))
-
+        self.draw.render_text(wrong_answer_text, MEDIUM_FONT, (SCREEN_WIDTH // 2, SCREEN_HEIGHT // 2))
 
     def check_question_status(self):
         if self.question.index < len(self.question.questions):
             self.button_handler.next_question()
         else:
-            self.text = "Wrong answer..Times up..you must arrest a suspect"
+            self.wrong_answer = "Wrong answer..Times up..you must arrest a suspect"
             self.button_handler.arrest()
-
 
     def run(self):
         self.timer.draw_timer()
-        self.draw_screen(self.message)
+        self.draw_screen()
         self.check_question_status()
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Suspects bugs fixed. Here's what appeared to be the main underlying issues:

- checked_button_pressed was being called after EACH suspect, rather than after ALL the suspects were drawn. 
  Resolved by saving the image positions to the dictionary and separating the check_button_pressed into a different function

- the suspects screen wasn't updating in the right place, as it was going straight to check_button_pressed, and not being updated until the user clicked. 
  Resolved by adding pygame.display.update() after the suspects are drawn and also removing the draw_suspect initialisation

- check_button_pressed: suspects were glitching when get_pressed was used. Researching this, it appears that MOUSEBUTTONDOWN triggers only at the point of the click, whereas get_pressed triggers at any point the mouse is clicked/held down. So even for short clicks, get_pressed may still be recognising the mouse as being held down as it whips through the loop.
  Resolved by replacing pressed[0] with MOUSEBUTTONDOWN. 

Random wrong answer also fixed by using getters and setters. Setting the state to "" each time the wrong_answer screen is changed.